### PR TITLE
Added virtual host flag

### DIFF
--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -13,11 +13,12 @@ var queueCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		queueName, _ := cmd.Flags().GetString("name")
 		hostname, _ := cmd.Flags().GetString("hostname")
+		virtualHost, _ := cmd.Flags().GetString("virtual-host")
 		port, _ := cmd.Flags().GetInt("port")
 		username, _ := cmd.Flags().GetString("username")
 		password, _ := cmd.Flags().GetString("password")
 
-		queue.Sniff(queueName, hostname, port, username, password)
+		queue.Sniff(queueName, hostname, port, virtualHost, username, password)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,5 +24,6 @@ func init() {
 	rootCmd.MarkFlagsRequiredTogether("username", "password")
 
 	rootCmd.PersistentFlags().StringP("hostname", "H", "localhost", "Hostname used to connect to a rabbitmq broker")
+	rootCmd.PersistentFlags().StringP("virtual-host", "V", "", "Virtual host (vhost) used to connect to a rabbitmq broker")
 	rootCmd.PersistentFlags().IntP("port", "P", 5672, "Port used to connect to a rabbitmq broker")
 }

--- a/cmd/topic.go
+++ b/cmd/topic.go
@@ -13,11 +13,12 @@ var topicCmd = &cobra.Command{
 		exchangeName, _ := cmd.Flags().GetString("exchange-name")
 		bindingKey, _ := cmd.Flags().GetString("binding-key")
 		hostname, _ := cmd.Flags().GetString("hostname")
+		virtualHost, _ := cmd.Flags().GetString("virtual-host")
 		port, _ := cmd.Flags().GetInt("port")
 		username, _ := cmd.Flags().GetString("username")
 		password, _ := cmd.Flags().GetString("password")
 
-		topic.Sniff(exchangeName, bindingKey, hostname, port, username, password)
+		topic.Sniff(exchangeName, bindingKey, hostname, port, virtualHost, username, password)
 	},
 }
 

--- a/internal/connection/connect.go
+++ b/internal/connection/connect.go
@@ -1,0 +1,20 @@
+package connection
+
+import (
+	"fmt"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func Connect(hostname string, port int, virtHost string, username string, password string) *amqp.Connection {
+	if len(virtHost) != 0 {
+		virtHost = "/" + virtHost
+	}
+
+	conn, err := amqp.Dial(fmt.Sprintf("amqp://%s:%s@%s:%d%s", username, password, hostname, port, virtHost))
+	if err != nil {
+		panic(fmt.Sprintf("Unable to connect to broker: %s", err.Error()))
+	}
+
+	return conn
+}

--- a/internal/queue/sniffer.go
+++ b/internal/queue/sniffer.go
@@ -3,14 +3,11 @@ package queue
 import (
 	"fmt"
 
-	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/joshmalbrecht/message-sniffer/internal/connection"
 )
 
-func Sniff(queueName string, hostname string, port int, username string, password string) {
-	conn, err := amqp.Dial(fmt.Sprintf("amqp://%s:%s@%s:%d", username, password, hostname, port))
-	if err != nil {
-		panic(fmt.Sprintf("Unable to connect to broker: %s", err.Error()))
-	}
+func Sniff(queueName string, hostname string, port int, virtHost string, username string, password string) {
+	conn := connection.Connect(hostname, port, virtHost, username, password)
 
 	defer conn.Close()
 

--- a/internal/topic/sniffer.go
+++ b/internal/topic/sniffer.go
@@ -3,14 +3,11 @@ package topic
 import (
 	"fmt"
 
-	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/joshmalbrecht/message-sniffer/internal/connection"
 )
 
-func Sniff(exchangeName string, bindingKey string, hostname string, port int, username string, password string) {
-	conn, err := amqp.Dial(fmt.Sprintf("amqp://%s:%s@%s:%d", username, password, hostname, port))
-	if err != nil {
-		panic(fmt.Sprintf("Unable to connect to broker: %s", err.Error()))
-	}
+func Sniff(exchangeName string, bindingKey string, hostname string, port int, virtHost string, username string, password string) {
+	conn := connection.Connect(hostname, port, virtHost, username, password)
 
 	defer conn.Close()
 


### PR DESCRIPTION
- The non-required virtual host flag is used to make a connection to a specific virtual host.
- Moved the broker connection logic into the internal/connection package.