### PR TITLE
Improved error messages

### DIFF
--- a/internal/queue/sniffer.go
+++ b/internal/queue/sniffer.go
@@ -6,20 +6,21 @@ import (
 	"github.com/joshmalbrecht/message-sniffer/internal/connection"
 )
 
-func Sniff(queueName string, hostname string, port int, virtHost string, username string, password string) {
+func Sniff(queueName string, hostname string, port int, virtHost string, username string, password string) error {
 	conn := connection.Connect(hostname, port, virtHost, username, password)
 
 	defer conn.Close()
 
 	ch, err := conn.Channel()
 	if err != nil {
-		panic(fmt.Sprintf("Unable to connect to channel: %s", err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to connect to channel: %s", err.Error()))
+		return err
 	}
 
 	defer ch.Close()
 
 	msgs, err := ch.Consume(
-		queueName, // queue
+		queueName, // queue name
 		"",        // consumer
 		false,     // auto-ack
 		false,     // exclusive
@@ -28,7 +29,8 @@ func Sniff(queueName string, hostname string, port int, virtHost string, usernam
 		nil,       // arguments
 	)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to consume message: %s", err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to consume message: %s", err.Error()))
+		return err
 	}
 
 	var forever chan struct{}
@@ -40,4 +42,6 @@ func Sniff(queueName string, hostname string, port int, virtHost string, usernam
 	}()
 
 	<-forever
+
+	return nil
 }

--- a/internal/topic/sniffer.go
+++ b/internal/topic/sniffer.go
@@ -6,14 +6,15 @@ import (
 	"github.com/joshmalbrecht/message-sniffer/internal/connection"
 )
 
-func Sniff(exchangeName string, bindingKey string, hostname string, port int, virtHost string, username string, password string) {
+func Sniff(exchangeName string, bindingKey string, hostname string, port int, virtHost string, username string, password string) error {
 	conn := connection.Connect(hostname, port, virtHost, username, password)
 
 	defer conn.Close()
 
 	ch, err := conn.Channel()
 	if err != nil {
-		panic(fmt.Sprintf("Unable to connect to channel: %s", err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to connect to channel: %s", err.Error()))
+		return err
 	}
 
 	defer ch.Close()
@@ -27,7 +28,8 @@ func Sniff(exchangeName string, bindingKey string, hostname string, port int, vi
 		nil,   // arguments
 	)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to declare queue: %s", err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to declare queue: %s", err.Error()))
+		return err
 	}
 
 	err = ch.QueueBind(
@@ -38,11 +40,12 @@ func Sniff(exchangeName string, bindingKey string, hostname string, port int, vi
 		nil,          // arguments
 	)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to bind queue: %s", err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to bind queue: %s", err.Error()))
+		return err
 	}
 
 	msgs, err := ch.Consume(
-		q.Name, // queue
+		q.Name, // queue name
 		"",     // consumer
 		true,   // auto ack
 		false,  // exclusive
@@ -60,4 +63,6 @@ func Sniff(exchangeName string, bindingKey string, hostname string, port int, vi
 	}()
 
 	<-forever
+
+	return nil
 }


### PR DESCRIPTION
- Replaced using panic() for errors and instead print the error message and return the error from the function. This prevents the stacktrace from being printed with the error message.